### PR TITLE
Old use of Buffer deprecated

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -71,7 +71,7 @@ function getAppleCertificate(publicKeyUrl, callback) {
 /* jslint bitwise:true */
 function convertTimestampToBigEndian(timestamp) {
   // The timestamp parameter in Big-Endian UInt-64 format
-  var buffer = new Buffer(8);
+  var buffer = new Buffer.alloc(8);
   buffer.fill(0);
 
   var high = ~~(timestamp / 0xffffffff); // jshint ignore:line


### PR DESCRIPTION
The signature '(size: number): Buffer' of 'Buffer' is deprecated.